### PR TITLE
Update tutorial-data-science-prepare-system.md

### DIFF
--- a/docs/data-science/tutorial-data-science-prepare-system.md
+++ b/docs/data-science/tutorial-data-science-prepare-system.md
@@ -31,7 +31,7 @@ In this tutorial, we use the [NYC Taxi and Limousine yellow dataset](/azure/open
 
 We utilize the notebook item in the Data Science experience to demonstrate various Fabric capabilities. The notebooks are available as Jupyter notebook files that can be imported to your Fabric-enabled workspace.
 
-1. Download the notebooks(.ipynb) files for this tutorial from the parent folder [Data Science Tutorial Source Code](https://github.com/microsoft/fabric-samples/tree/main/docs-samples/data-science/data-science-tutorial).
+1. Ensuring that you are downloading the notebooks(.ipynb) files as raw, download the notebooks(.ipynb) files for this tutorial from the parent folder [Data Science Tutorial Source Code](https://github.com/microsoft/fabric-samples/tree/main/docs-samples/data-science/data-science-tutorial).
 
 1. Switch to the Data Science experience using the experience switcher icon at the left corner of your homepage.
 

--- a/docs/data-science/tutorial-data-science-prepare-system.md
+++ b/docs/data-science/tutorial-data-science-prepare-system.md
@@ -31,7 +31,7 @@ In this tutorial, we use the [NYC Taxi and Limousine yellow dataset](/azure/open
 
 We utilize the notebook item in the Data Science experience to demonstrate various Fabric capabilities. The notebooks are available as Jupyter notebook files that can be imported to your Fabric-enabled workspace.
 
-1. Ensuring that you are downloading the notebooks(.ipynb) files as raw, download the notebooks(.ipynb) files for this tutorial from the parent folder [Data Science Tutorial Source Code](https://github.com/microsoft/fabric-samples/tree/main/docs-samples/data-science/data-science-tutorial).
+1. Download the notebook(.ipynb) files for this tutorial from the parent folder: [Data Science Tutorial Source Code](https://github.com/microsoft/fabric-samples/tree/main/docs-samples/data-science/data-science-tutorial). Make sure to download the files by using the "Raw" file link in GitHub.
 
 1. Switch to the Data Science experience using the experience switcher icon at the left corner of your homepage.
 


### PR DESCRIPTION
We have noticed some customers are downloading the .ipynb files as HTML file because GitHub renders the .ipynb files in the browser. Importing thise HTML rendered version fails. So customers should download the .ipynb file as raw using "Download raw file"