### PR TITLE
Update onelake-onecopy-quickstart.md

### DIFF
--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -20,8 +20,6 @@ In this guide, you will:
 - Analyze and transform data with Spark using a Fabric notebook.
 
 - Query one copy of data on OneLake with SQL.
-  
-- Please note as for tables inside of Lakehouse: they should be created inside of the Table folder, only, and not using intermediate folders in between.
 
 [!INCLUDE [preview-note](../includes/preview-note.md)]
 
@@ -50,6 +48,7 @@ In this guide, you will:
    :::image type="content" source="media\onelake-onecopy-quickstart\new-notebook-quickstart.png" alt-text="Screenshot of creating new notebook in Fabric." lightbox="media\onelake-onecopy-quickstart\new-notebook-quickstart.png":::
 
 1. Using the Fabric notebook, convert the CSV files to delta format. The following code snippet reads data from user created directory /Files/dimension_city and converts it to a delta table dim_city.
+   - Please note as for tables inside of Lakehouse: they should be created inside of the Table folder, only, and not using intermediate folders in between.
 
     ```python
     import os

--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -29,6 +29,9 @@ In this guide, you will:
 - A workspace with a lakehouse item
 - Download the WideWorldImportersDW dataset to your computer to follow along with the instructions in this guide.  You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/) to connect to "https://azuresynapsestorage.blob.core.windows.net/sampledata/WideWorldImportersDW/csv/full/dimension_city" and download the set of csv files. You can also use your own csv data and update the details as required.
 
+[!Note]
+> When creating, loading, or using shortcut Delta-Parquet data directly under the Table section of the lakehouse. Keep in mind that you should not nest your tables under additional subfolders in the Tables section as the Lakehouse will not automatically recognize it as a table and they will be labeled as Unidentified.
+
 ## Steps
 
 1. In OneLake file explorer, navigate to your lakehouse and under the /Files directory, create a subdirectory named dimension_city.

--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -51,7 +51,6 @@ In this guide, you will:
    :::image type="content" source="media\onelake-onecopy-quickstart\new-notebook-quickstart.png" alt-text="Screenshot of creating new notebook in Fabric." lightbox="media\onelake-onecopy-quickstart\new-notebook-quickstart.png":::
 
 1. Using the Fabric notebook, convert the CSV files to delta format. The following code snippet reads data from user created directory /Files/dimension_city and converts it to a delta table dim_city.
-   - Please note as for tables inside of Lakehouse: they should be created inside of the Table folder, only, and not using intermediate folders in between.
 
     ```python
     import os

--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -29,8 +29,8 @@ In this guide, you will:
 - A workspace with a lakehouse item
 - Download the WideWorldImportersDW dataset to your computer to follow along with the instructions in this guide.  You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/) to connect to "https://azuresynapsestorage.blob.core.windows.net/sampledata/WideWorldImportersDW/csv/full/dimension_city" and download the set of csv files. You can also use your own csv data and update the details as required.
 
-[!Note]
->Create, load, or shortcut Delta-Parquet data directly under the Table section of the Lakehouse. Do not nest your tables under additional subfolders in the Tables section as the Lakehouse will not automatically recognize it as a table and label it as Unidentified.
+> [!NOTE]
+> Create, load, or create a shortcut Delta-Parquet data directly under the Tables section of the Lakehouse. Do not nest your tables under additional subfolders in the Tables section as the Lakehouse will not automatically recognize it as a table and label it as Unidentified.
 
 ## Steps
 

--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -30,7 +30,7 @@ In this guide, you will:
 - Download the WideWorldImportersDW dataset to your computer to follow along with the instructions in this guide.  You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/) to connect to "https://azuresynapsestorage.blob.core.windows.net/sampledata/WideWorldImportersDW/csv/full/dimension_city" and download the set of csv files. You can also use your own csv data and update the details as required.
 
 [!Note]
-> When creating, loading, or using shortcut Delta-Parquet data directly under the Table section of the lakehouse. Keep in mind that you should not nest your tables under additional subfolders in the Tables section as the Lakehouse will not automatically recognize it as a table and they will be labeled as Unidentified.
+>Create, load, or shortcut Delta-Parquet data directly under the Table section of the Lakehouse. Do not nest your tables under additional subfolders in the Tables section as the Lakehouse will not automatically recognize it as a table and label it as Unidentified.
 
 ## Steps
 

--- a/docs/onelake/onelake-onecopy-quickstart.md
+++ b/docs/onelake/onelake-onecopy-quickstart.md
@@ -20,6 +20,8 @@ In this guide, you will:
 - Analyze and transform data with Spark using a Fabric notebook.
 
 - Query one copy of data on OneLake with SQL.
+  
+- Please note as for tables inside of Lakehouse: they should be created inside of the Table folder, only, and not using intermediate folders in between.
 
 [!INCLUDE [preview-note](../includes/preview-note.md)]
 


### PR DESCRIPTION
adding this information: 
- Please note as for tables inside of Lakehouse: they should be created inside of the Table folder, only, and not using intermediate folders in between.