### PR TITLE
Updated text on Activity Details page 

### DIFF
--- a/docs/admin/feature-usage-adoption.md
+++ b/docs/admin/feature-usage-adoption.md
@@ -60,7 +60,7 @@ Continuing the example from the [Activity Overview](#activity-overview-page) pag
 
 ### Activity Details page
 
-The Activity Details page shows information related to specific or multiple capacity or workspaces activities. You can only get to the *Activity Details* page from the page navigation menu, or by drilling through from the [Activity Overview](#activity-overview-page) or [Analysis](#analysis-page) pages. To drill through, right-click a result and then select the *Activity Details* page. After drilling through, you see the following information for the selected activities:
+The Activity Details page shows information related to specific or multiple capacity or workspaces activities. You can only get to the *Activity Details* page by drilling through from the [Activity Overview](#activity-overview-page) or [Analysis](#analysis-page) pages. To drill through, right-click a result and then select the *Activity Details* page. After drilling through, you see the following information for the selected activities:
 
 * **Creation time** - The time the activity was registered
 


### PR DESCRIPTION
The updated Feature Usage and Adoption Report does not support direct navigation to Activity Details page.

Updated text on Activity Details page to remove direct navigation text.