### PR TITLE
Update onelake-shortcuts.md

### DIFF
--- a/docs/onelake/onelake-shortcuts.md
+++ b/docs/onelake/onelake-shortcuts.md
@@ -212,13 +212,14 @@ When creating shortcuts between multiple Fabric items within a workspace, you ca
 
 ## Limitations and Considerations
 
-- The maximum number of shortcuts per Fabric item is 10,000.
+- The maximum number of shortcuts per Fabric item is 10,000.In this context the term item refers to: apps, lakehouses, 
+   warehouses, reports, and more.
 - The maximum number of shortcuts in a single OneLake path is 10.
 - The maximum number of direct shortcut to shortcut links is 5.
 - ADLS and S3 shortcut target paths can't contain any reserved characters from RCF 3986 section 2.2.
 - OneLake shortcut target paths can’t contain “%” characters.
 - Shortcuts don't support nonlatin characters.
-- Copy Blob api not supported for ADLS or S3 shortcuts.
+- Copy Blob API not supported for ADLS or S3 shortcuts.
 - Copy function doesn't work on shortcuts that directly point to ADLS containers. It's recommended to create ADLS shortcuts to a directory that is at least one level below a container.
 - OneLake shortcuts pointing to ADLS or S3 shortcuts isn't supported.
 - Additional shortcuts can't be created inside ADLS or S3 shortcuts.

--- a/docs/onelake/onelake-shortcuts.md
+++ b/docs/onelake/onelake-shortcuts.md
@@ -212,8 +212,7 @@ When creating shortcuts between multiple Fabric items within a workspace, you ca
 
 ## Limitations and Considerations
 
-- The maximum number of shortcuts per Fabric item is 10,000.In this context the term item refers to: apps, lakehouses, 
-   warehouses, reports, and more.
+- The maximum number of shortcuts per Fabric item is 10,000. In this context the term item refers to: apps, lakehouses, warehouses, reports, and more.
 - The maximum number of shortcuts in a single OneLake path is 10.
 - The maximum number of direct shortcut to shortcut links is 5.
 - ADLS and S3 shortcut target paths can't contain any reserved characters from RCF 3986 section 2.2.


### PR DESCRIPTION
propose the following change:
"## Limitations and Considerations

- The maximum number of shortcuts per Fabric item is 10,000.In this context the term item refers to: apps, lakehouses,  warehouses, reports, and more."

Based on this - https://learn.microsoft.com/en-us/fabric/get-started/fabric-home. for clarification of the doc