### PR TITLE
bugfix SparkSQL to process as multiple statements

### DIFF
--- a/docs/data-engineering/native-execution-engine-overview.md
+++ b/docs/data-engineering/native-execution-engine-overview.md
@@ -90,8 +90,8 @@ The mechanisms to enable the Native Execution Engine at the tenant, workspace, a
 
 ```sql
 %%sql 
-SET spark.native.enabled=FALSE 
-SET spark.gluten.enabled=FALSE 
+SET spark.native.enabled=FALSE; 
+SET spark.gluten.enabled=FALSE; 
 ```
 
 # [PySpark](#tab/pyspark)
@@ -129,8 +129,8 @@ After executing the query in which the native execution engine is disabled, you 
 
 ```sql
 %%sql 
-SET spark.native.enabled=TRUE 
-SET spark.gluten.enabled=TRUE 
+SET spark.native.enabled=TRUE; 
+SET spark.gluten.enabled=TRUE; 
 ```
 
 # [PySpark](#tab/pyspark)


### PR DESCRIPTION
Existing provided code doesn't work as it operates as a single statement setting the value of spark.native.enabled to 'FALSE SET spark.gluten.enabled=FALSE'

FYI @ekote 

![image](https://github.com/MicrosoftDocs/fabric-docs/assets/52209784/29483c9f-12a5-4706-b243-fdf59af9f93c)
