### PR TITLE
Fix memory sizes for Spark Nodes

### DIFF
--- a/docs/data-engineering/spark-compute.md
+++ b/docs/data-engineering/spark-compute.md
@@ -69,7 +69,7 @@ An Apache Spark pool instance consists of one head node and worker nodes, could 
 
 ## Node sizes
 
-A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 28 GB of memory) to a large compute node (with 64 vCore and 448 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
+A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 28 GB of memory) to an double extra large compute node (with 64 vCore and 400 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
 
 | Size | vCore | Memory |
 |--|--|--|

--- a/docs/data-engineering/spark-compute.md
+++ b/docs/data-engineering/spark-compute.md
@@ -77,7 +77,7 @@ A Spark pool can be defined with node sizes that range from a small compute node
 | Medium | 8 | 56 GB |
 | Large | 16 | 112 GB |
 | X-Large | 32 | 224 GB |
-| XX-Large | 64 | 448 GB |
+| XX-Large | 64 | 400 GB |
 
 ## Autoscale
 

--- a/docs/data-engineering/spark-compute.md
+++ b/docs/data-engineering/spark-compute.md
@@ -69,15 +69,15 @@ An Apache Spark pool instance consists of one head node and worker nodes, could 
 
 ## Node sizes
 
-A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 32 GB of memory) to a large compute node (with 64 vCore and 512 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
+A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 28 GB of memory) to a large compute node (with 64 vCore and 448 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
 
 | Size | vCore | Memory |
 |--|--|--|
-| Small | 4 | 32 GB |
-| Medium | 8 | 64 GB |
-| Large | 16 | 128 GB |
-| X-Large | 32 | 256 GB |
-| XX-Large | 64 | 512 GB |
+| Small | 4 | 28 GB |
+| Medium | 8 | 56 GB |
+| Large | 16 | 112 GB |
+| X-Large | 32 | 224 GB |
+| XX-Large | 64 | 448 GB |
 
 ## Autoscale
 

--- a/docs/data-engineering/spark-compute.md
+++ b/docs/data-engineering/spark-compute.md
@@ -69,7 +69,7 @@ An Apache Spark pool instance consists of one head node and worker nodes, could 
 
 ## Node sizes
 
-A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 28 GB of memory) to an double extra large compute node (with 64 vCore and 400 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
+A Spark pool can be defined with node sizes that range from a small compute node (with 4 vCore and 28 GB of memory) to a double extra large compute node (with 64 vCore and 400 GB of memory per node). Node sizes can be altered after pool creation, although the active session would have to be restarted.
 
 | Size | vCore | Memory |
 |--|--|--|


### PR DESCRIPTION
These sizes no longer align with what the UI shows
