### PR TITLE
fix: swap wrong relative links

### DIFF
--- a/docs/get-started/direct-lake-overview.md
+++ b/docs/get-started/direct-lake-overview.md
@@ -24,7 +24,7 @@ On the other hand, with import mode, performance can be better because the data 
 
 Direct Lake mode eliminates the import requirement by loading the data directly from OneLake. Unlike DirectQuery, there's no translation from DAX or MDX to other query languages or query execution on other database systems, yielding performance similar to import mode. Because there's no explicit import process, it's possible to pick up any changes at the data source as they occur, combining the advantages of both DirectQuery and import modes while avoiding their disadvantages. Direct Lake mode can be the ideal choice for analyzing very large models and models with frequent updates at the data source.
 
-Direct Lake also supports [row-level security](../security/service-admin-object-level-security.md) and [object-level](../security/service-admin-row-level-security.md) security so users only see the data they have permission to see.
+Direct Lake also supports [row-level security](../security/service-admin-row-level-security.md) and [object-level](../security/service-admin-object-level-security.md) security so users only see the data they have permission to see.
 
 ## Prerequisites
 


### PR DESCRIPTION
The links referring to the object level security page and the row level security page are swapped, this PR fixes this.