### PR TITLE
fix typo in runtime version

### DIFF
--- a/docs/data-engineering/runtime-1-3.md
+++ b/docs/data-engineering/runtime-1-3.md
@@ -16,7 +16,7 @@ no-loc: [Copilot]
 
 Fabric runtime offers a seamless integration with Azure. It provides a sophisticated environment for both data engineering and data science projects that use Apache Spark. This article provides an overview of the essential features and components of Fabric Runtime 1.3, the newest runtime for big data computations.
 
-Microsoft Fabric Runtime 1.2 is the latest GA runtime version and incorporates the following components and upgrades designed to enhance your data processing capabilities:
+Microsoft Fabric Runtime 1.3 is the latest GA runtime version and incorporates the following components and upgrades designed to enhance your data processing capabilities:
 - Apache Spark 3.5
 - Operating System: Mariner 2.0
 - Java: 11


### PR DESCRIPTION
The doc has a typo referencing runtime 1.2