### PR TITLE
Update collation.md

### DIFF
--- a/docs/data-warehouse/collation.md
+++ b/docs/data-warehouse/collation.md
@@ -51,7 +51,8 @@ You can easily create a new warehouse with case-insensitive collation using [Vis
      POST https://api.fabric.microsoft.com/v1/workspaces/<workspaceID>/items HTTP/1.1
      Content-Type: application/json
      Authorization: Bearer <bearer token>
-    { 
+
+   { 
       "type": "Warehouse", 
       "displayName": "<Warehouse name here>", 
       "description": "<Warehouse description here>", 


### PR DESCRIPTION
Added a line of whitespace between the bearer token and the opening  brace. This whitespace line is needed for the code to work in the visual studio extension

External to Microsoft - MVP

When running in Visual Studio code with the extension outlined in the article, there must be a line of whitespace between the bearer token and the opening curly brace.
Feel free to contact marty@data-marty.com if you require additional information..

