### PR TITLE
Fix link to sharing trial capacitues

### DIFF
--- a/docs/get-started/fabric-trial.md
+++ b/docs/get-started/fabric-trial.md
@@ -64,7 +64,7 @@ You can start a trial several different ways. The first two methods make you the
 - Attempt to use a Fabric feature. If your organization enabled self-service, attempting to use a Fabric feature launches a Fabric trial.
 - Join a trial started by a coworker by adding your workspace to that existing trial capacity. This action only is possible if the owner gives you, or gives the entire organization, **Contributor permissions** to the trial.
 
-For more information, see {Sharing trial capacities](#sharing-trial-capacities).
+For more information, see [Sharing trial capacities](#sharing-trial-capacities).
 
 Follow these steps to start your Fabric capacity trial and become the Capacity administrator of that trial.
 

--- a/docs/get-started/fabric-trial.md
+++ b/docs/get-started/fabric-trial.md
@@ -64,7 +64,7 @@ You can start a trial several different ways. The first two methods make you the
 - Attempt to use a Fabric feature. If your organization enabled self-service, attempting to use a Fabric feature launches a Fabric trial.
 - Join a trial started by a coworker by adding your workspace to that existing trial capacity. This action only is possible if the owner gives you, or gives the entire organization, **Contributor permissions** to the trial.
 
-For more information, see [Sharing trial capacities](#sharing-trial-capacities).
+For more information, see [Sharing trial capacities](#share-trial-capacities).
 
 Follow these steps to start your Fabric capacity trial and become the Capacity administrator of that trial.
 


### PR DESCRIPTION
Content had a { rather than a [ so link wasn't working
