### PR TITLE
Point dbt tutorial to jaffle-shop-classic instead of jaffle-shop

### DIFF
--- a/docs/data-warehouse/tutorial-setup-dbt.md
+++ b/docs/data-warehouse/tutorial-setup-dbt.md
@@ -60,7 +60,7 @@ This tutorial uses [Visual Studio Code](https://code.visualstudio.com/download),
     - Or, for example, you can use the `git clone` command:
 
     ```powershell
-    git clone https://github.com/dbt-labs/jaffle_shop.git
+    git clone https://github.com/dbt-labs/jaffle-shop-classic.git
     ```
 
 1. Open the `jaffle_shop` project folder in Visual Studio Code.


### PR DESCRIPTION
jaffle-shop was changed to be specific to dbt Cloud. jaffle-shop-classic is what this tutorial should refer to now.
