### PR TITLE
Update service-security-private-links-on-premises.md

### DIFF
--- a/docs/enterprise/powerbi/service-security-private-links-on-premises.md
+++ b/docs/enterprise/powerbi/service-security-private-links-on-premises.md
@@ -105,6 +105,12 @@ The following screenshot shows an example of DNS Conditional Forwarder entries i
 
 :::image type="content" source="media/service-security-private-links-on-premises/service-security-private-links-on-premises-09.png" alt-text="Screenshot of an IP address used for the conditional forwarder.":::
 
+> [!IMPORTANT]
+> Fabric now supports enabling private endpoints without disabling public access. In this scenario, you must additionally configure the following Conditional Forwarders on your on-premises DNS server:
+>
+> - app.powerbi.com
+> - app.fabric.microsoft.com
+
 
 ## Verification of successful configuration
 


### PR DESCRIPTION
Add DNS conditional forwarder guidance for private endpoints with public access.

Based on our testing, in this scenario, if these settings are not configured, Fabric will be accessed via Public.
