### PR TITLE
Add limitation - Pipelines cannot read from variable library

### DIFF
--- a/docs/security/security-workspace-level-private-links-support.md
+++ b/docs/security/security-workspace-level-private-links-support.md
@@ -338,6 +338,7 @@ For more information, see [Private links for Azure and Fabric Events](/fabric/re
 - For Data Engineering workloads:
    - To query Lakehouse files or tables from a workspace that has workspace-level private link enabled, you must create a cross-workspace managed private endpoint connection to access resources in the other workspace. <!--For instructions, see [Cross workspace communication](security-cross-workspace-communication.md).-->
    - You can use either relative or full paths to query files or tables within the same workspace, or use a cross-workspace managed private endpoint connection to access them from another workspace. To read files in a Lakehouse located in another workspace, use a fully qualified path that includes the workspace ID and lakehouse ID (not their display names). This approach ensures the Spark session can resolve the path correctly and avoids socket timeout errors. [Learn more](workspace-outbound-access-protection-data-engineering.md#understanding-file-path-behavior-in-fabric-notebooks).
+- Variable Libraries cannot be accessed from a Pipeline.
 - Current limitations for Private Link with an eventhouse:
    - Copilot features: Machine learning workloads might experience limited functionality due to a known regression.
    - Eventstream pull: Eventstream workloads don't currently support full polling functionality.


### PR DESCRIPTION
# Thank you for contributing to Microsoft Fabric documentation

## Fill out these items before submitting your pull request:

If you are working internally at Microsoft:
**Provide a link to an Azure DevOps Boards work item that tracks this feature/update.**

N/A – Documentation update to reflect current product limitation observed in customer tenant deployment involving Workspace Private Link preventing Fabric Pipelines from resolving Variable Library references. No feature change required.

**Who is your primary Skilling team contact?**

@MicrosoftDocs/fabric-content

## For internal Microsoft contributors, check off these quality control items as you go

- [x] 1. Check the Acrolinx report
- [x] 2. Successful build with no warnings or suggestions
- [x] 3. Preview the pages
- [x] 4. Check the Table of Contents