### PR TITLE
Clarify scope of M365 metadata sharing tenant setting

### DIFF
--- a/docs/admin/admin-share-power-bi-metadata-microsoft-365-services.md
+++ b/docs/admin/admin-share-power-bi-metadata-microsoft-365-services.md
@@ -5,7 +5,7 @@ author: msmimart
 ms.author: mimart
 ms.reviewer: jadelynray
 ms.topic: concept-article
-ms.date: 12/05/2025
+ms.date: 05/22/2026
 LocalizationGroup: Admin
 #customer intent: As a Fabric admin, I need to know what information is passed from Fabric and Microsoft Graph to Microsoft 365.
 ---
@@ -14,25 +14,50 @@ LocalizationGroup: Admin
 
 This article is aimed at Fabric administrators and decision makers who need to know how and where Fabric metadata is being used.
 
-Fabric metadata sharing with Microsoft 365 services is a feature that allows metadata from Fabric to be shared with Microsoft 365 services (typically via [Microsoft Graph](/graph/overview)) and combined with data from across Microsoft 365, Windows, and Enterprise Mobility + Security (EMS) to build apps for organizations and consumers that interact with millions of users. The feature is enabled by default when your Fabric home tenant and Microsoft 365 tenant are in the same geographical region.
+The **Share Fabric data with your Microsoft 365 services** tenant setting controls whether Power BI and Microsoft Fabric automatically send information about your organization's Fabric content to Microsoft 365. When this setting is turned on, Fabric sends details about your reports, dashboards, and other content to Microsoft 365 in the background—without anyone needing to take action. Microsoft 365 then uses this information to help users find and get back to their Fabric content through search results, the Quick Access list on Office.com, and personalized recommendations.
 
-When shared with Microsoft 365 services, Fabric content will be listed in the Quick Access list on the Office.com home page. The Fabric content affected includes reports, dashboards, apps, workbooks, paginated reports, and workspaces. The information required by the Quick Access functionality includes:
+Behind the scenes, this information flows through [Microsoft Graph](/graph/overview). The setting is turned on by default when your Fabric tenant and Microsoft 365 tenant are in the same geographic region.
 
-* The display name of the content
-* When the content was last accessed
-* The type of content that was accessed (report, app, dashboard, scorecard, etc.)
+### What information is shared
 
-See [more about the Fabric data that is shared with Microsoft 365 services](#data-that-is-shared-with-microsoft-365).
+When this setting is turned on, Fabric sends the following information to Microsoft 365:
+
+| Content type | What's shared |
+|---|---|
+| Power BI reports | Broad item context including the report name, description, web address, who has access, workspace, who created & last modified the report, dates of creation & last update, page names, chart titles, and column/measure names |
+| Power BI workspace apps | Basic details only (name, web address, who has access, workspace) |
+| Power BI dashboards | Basic details only (name, web address, who has access, workspace) |
+| Power BI paginated reports (RDL) | Basic details only (name, web address, who has access, workspace) |
+
+Power BI also shares information about how users interact with content when this setting is turned on—for example, which reports a user has viewed. Microsoft 365 uses these signals to show recently accessed and recommended Fabric content on Office.com.
+
+For the complete list of properties that are shared, see [Data that is shared with Microsoft 365](#data-that-is-shared-with-microsoft-365).
+
+### What this setting doesn't control
+
+Turning off this setting doesn't block Fabric content from appearing in Microsoft 365 experience. Users who have access to Fabric content can still take an explicit action to use Fabric content in M365 products. For instance, the following experiences continue to work even when this setting is turned off, because they depend on a user actively doing something:
+
+- **Excel pivot tables connected to Power BI semantic models** -- In Excel, users can discover all the Power BI models they have access to and explore that data in Excel spreadsheets using PivotTables and other Excel capabilities. This behavior is not affected by the Share Fabric data with M365 tenant setting. Access to connect Excel to Power BI models does require Fabric admin approval via a distinct tenant setting. For more information, see [Power BI semantic model experience in Excel](/power-bi/collaborate-share/office-integration/service-connect-excel-power-bi-datasets).
+
+- **Link previews in Teams and Outlook** — When a user pastes a link to a Power BI report in a Teams chat or Outlook email, people who have access to that report always see a preview with the report name and other metadata. This behavior is not affected by the Share Fabric data with M365 tenant setting. For more information, see [Power BI link previews in Teams](/power-bi/collaborate-share/office-integration/service-teams-link-preview).
+
+- **Fabric data agents in the Microsoft 365 Agent Store** — If your organization has published Fabric data agents to the Microsoft 365 Agent Store, users with access can  chat with the agent in M365. This behavior is not affected by the Share Fabric data with M365 tenant setting. For more information, see [Use a Fabric data agent in Microsoft 365 Copilot](/fabric/data-science/data-agent-microsoft-365-copilot).
+
+- **[Frontier Only] Asking Microsoft 365 Copilot about Power BI data** — Microsoft 365 Copilot can answer questions using Power BI reports and semantic models that the user has permission to view, regardless of this setting. Access to this feature does require M365 admin approval. For more information, see [Fabric IQ in M365 Copilot (Frontier)](/fabric/iq/connectors/m365-copilot-overview).
+
+- **[Frontier Only] Asking Microsoft 365 Cowork about Power BI data** — Power BI reports and semantic models that the user has permission to view can be used as a part of Cowork workflows. Users can request emails or schedule meetings triggered by the latest metrics or produce deep analysis that incorporates the context of Work IQ (e.g. emails, Teams chats, docs) into the insights from Power BI data.  This behavior is not affected by the Share Fabric data with M365 tenant setting. M365 admins can disable access to the Cowork agent for their organization and access to the Fabric IQ plugin requires M365 admin approval. For more information, see [Fabric IQ in Cowork (Frontier)](/fabric/iq/connectors/cowork-overview).
+
+These experiences all rely on the user being signed in and having permission to the content—they don't rely on Fabric sending information to Microsoft 365 in the background.
 
 ## Data residency
 
-Fabric and Microsoft 365 are distinct and separately operated Microsoft cloud services, each deployed according to its own service-specific data center alignment rules, even when purchased together. As a result, it's possible that your Microsoft 365 Services and your Fabric service are not deployed in the same geographic region.
+Fabric and Microsoft 365 are separate cloud services that might be hosted in different geographic regions, even if you purchased them together.
 
-By default, Fabric metadata is available only in the region where the Fabric tenant is located. However, you can allow Fabric to share metadata across regions by turning on a toggle switch in the **Users can see Microsoft Fabric metadata in Microsoft 365** tenant setting. For more information, see [How to turn sharing with Microsoft 365 services on and off](#how-to-turn-sharing-with-microsoft-365-services-on-and-off).
+By default, Fabric only shares information within the geography where your Fabric tenant is located. If your Microsoft 365 tenant is in a different geography, you need to allow cross-geo sharing for the integration to work. You can do this with a second toggle in the tenant setting. For more information, see [How to turn sharing with Microsoft 365 services on and off](#how-to-turn-sharing-with-microsoft-365-services-on-and-off).
 
 ### Where is Fabric data stored?
 
-For more information about data storage locations, see [Find the default region for your organization](/power-bi/admin/service-admin-where-is-my-tenant-located) and [Product Availability by Geography](https://powerplatform.microsoft.com/availability-reports/).
+For more information about data storage locations, see [Find your Fabric home region](/power-bi/admin/service-admin-where-is-my-tenant-located) and [Product Availability by Geography](https://powerplatform.microsoft.com/availability-reports/).
 
 ### Where is Microsoft 365 data stored?
 
@@ -40,9 +65,14 @@ For more information about data storage for Microsoft 365, see [Where your Micro
 
 ## How to turn sharing with Microsoft 365 services on and off
 
-Sharing metadata with Microsoft 365 services is controlled by the **Share Fabric data with your Microsoft 365 services** tenant setting. The setting is **Enabled** by default. To turn off the feature, or to turn it on again after it's been turned off, go to **Admin portal** > **Tenant settings** > **Share Fabric data with your Microsoft 365 services** and set the toggle as appropriate. Once the setting is enabled or disabled, it may take up to 24 hours for you to see changes.
+The **Share Fabric data with your Microsoft 365 services** tenant setting is turned on by default. To change it:
 
-By default, Fabric data is available only in the region where the Fabric tenant is located. To allow Fabric to share metadata across regions, set the second toggle switch to **Enabled**. When you enable the second toggle, you acknowledge that Fabric data may flow outside the geographic region it's stored in.
+1. Go to **Admin portal** > **Tenant settings** > **Share Fabric data with your Microsoft 365 services**.
+1. Set the toggle to **Enabled** or **Disabled** as needed.
+
+Changes can take up to 24 hours to take effect.
+
+To allow sharing across geographic regions (when your Fabric and Microsoft 365 tenants are in different regions), set the second toggle to **Enabled**. By turning on this toggle, you acknowledge that Fabric data might flow outside its current geographic region.
 
 > [!NOTE]
 > The second toggle is visible only when the main sharing toggle is enabled.
@@ -53,9 +83,9 @@ By default, Fabric data is available only in the region where the Fabric tenant 
 
 ## Data that is shared with Microsoft 365
 
-The tables below lists examples of the data that is shared with Microsoft 365 services.
+The tables below show what specific information Fabric sends to Microsoft 365 when sharing is turned on.
 
-**Item metadata that is mainly used when using the "search" mechanism to look for Fabric content within your Microsoft 365 services**
+**Item details (used for search and discovery in Microsoft 365)**
 
 |Property|What is Shared|Example|
 |---------|---------|---------|---------|
@@ -75,7 +105,7 @@ The tables below lists examples of the data that is shared with Microsoft 365 se
 |ChartTitles|Display names for visualizations in the report layout |Regional sales over time|  
 |FieldNames|Names of columns and measures used in the report|revenue, date, product_category|
 
-**User activity that is mainly leveraged for showing Fabric content within your "Recents" and "Recommended" sections at Office.com**
+**User activity (used to show recently accessed and recommended content on Office.com)**
 
 |Property|What is Shared|Example|
 |---------|---------|---------|---------|


### PR DESCRIPTION
## Summary

This PR updates the 'Share data with your Microsoft 365 services' admin documentation to:

1. **Clarify the setting's purpose** — Explicitly state that this tenant setting governs background/automatic metadata sharing only (not all Fabric data in M365).

2. **Add content type detail** — New table showing what metadata is indexed per content type:
   - Power BI reports: full metadata
   - Power BI apps, dashboards, paginated reports (RDL): limited metadata

3. **Document user behavior signals** — Note that PBI shares user activity signals (e.g., report views) when enabled.

4. **Add 'What this setting doesn't control' section** — Three scenarios that still work when the toggle is off:
   - Link previews in Teams/Outlook
   - Fabric data agents in the M365 Agent Store
   - M365 Copilot questions about Power BI data

5. **Simplify language** — Rewritten for an IT admin audience (less jargon, clearer explanations, numbered steps for the how-to).

## Related docs
- [Power BI link previews in Teams](https://learn.microsoft.com/power-bi/collaborate-share/office-integration/service-teams-link-preview)
- [Fabric data agents in M365 Copilot](https://learn.microsoft.com/fabric/data-science/data-agent-microsoft-365-copilot)
