### PR TITLE
Add Pipelines to item reference variable type list

### DIFF
--- a/docs/cicd/variable-library/item-reference-variable-type.md
+++ b/docs/cicd/variable-library/item-reference-variable-type.md
@@ -82,6 +82,7 @@ The following is a list of items that are currently supported using item referen
 - [Shortcut for a lakehouse ](../../onelake/assign-variables-to-shortcuts.md)
 - [User data functions](../../data-engineering/user-data-functions/connect-to-data-sources.md)
 - Notebook, through [NotebookUtils](../../data-engineering/notebookutils/notebookutils-variable-library.md)
+- Pipelines
  
 
 >[!NOTE]


### PR DESCRIPTION
This pull request updates the documentation for item reference variable types, specifically by expanding the list of supported items. The main change is the addition of "Pipelines" as a supported item type.

Documentation update:

* Added "Pipelines" to the list of currently supported items in the item reference variable type documentation (`item-reference-variable-type.md`).
