### PR TITLE
Add MigrateGen1Dataflow to Fabric admin operation list

### DIFF
--- a/docs/admin/operation-list.md
+++ b/docs/admin/operation-list.md
@@ -440,6 +440,7 @@ The following operations are available in the audit logs.
 | Load Spark App Log | :::no-loc text="LoadSparkAppLog"::: |   |
 | Manage Relationships | :::no-loc text="ManageRelationships"::: |   |
 | Map Upn | :::no-loc text="MapUpn"::: |   |
+| Migrate Gen1 Dataflow | :::no-loc text="MigrateGen1Dataflow"::: | Generated when a Power BI Gen1 dataflow is migrated in place to the Gen2.1 native dataflow format using the Upgrade Wizard. |
 | Migrated dataflow storage location | :::no-loc text="MigratedDataflowStorageLocation"::: | Not currently used  |
 | Migrated workspace to a capacity | :::no-loc text="MigrateWorkspaceIntoCapacity"::: |   |
 | Modified OneLake default tier | :::no-loc text="ModifiedDefaultTier"::: |   |


### PR DESCRIPTION
## Summary
Adds the customer-facing audit operation **Migrate Gen1 Dataflow** (`MigrateGen1Dataflow`) to the Fabric admin operation list. The friendly name, operation name, and description match the registered Trident audit activity (`AuditActivityEvents.xml`) for the Power BI Dataflows **Gen1 → Gen2.1** in-place migration (Upgrade Wizard).

Placed alphabetically, immediately before *Migrated dataflow storage location* (1 addition, 0 deletions).

## Internal tracking (Microsoft)
- **ADO work item:** US 7514461 — Task 4003 (Register New Trident Audit Activities), Power BI Dataflows Gen1→Gen2.1 migration audit onboarding.
- **Target:** Public Preview (~2026-08-01).
- **Registration PRs:** powerbi `1006642` (O365 registration) and `994126` (audit emission, merged).

## Notes for reviewers
Single table-row addition — no new file, no TOC change required. Draft until the Gen1→Gen2.1 audit onboarding is ready to publish for Public Preview.
