### PR TITLE
Add resource profiles overview page and group resource profile docs in TOC

### DIFF
--- a/docs/data-engineering/resource-profiles-overview.md
+++ b/docs/data-engineering/resource-profiles-overview.md
@@ -1,0 +1,61 @@
+---
+title: Resource profiles in Microsoft Fabric overview
+description: Understand what Spark resource profiles are in Microsoft Fabric, how the built-in profiles map to workloads, and how auto-update keeps their configurations current.
+ms.service: fabric
+ms.subservice: data-engineering
+ms.topic: overview
+ms.date: 07/23/2026
+author: SnehaGunda
+ms.author: sngun
+ms.reviewer: saravi
+ai-usage: ai-assisted
+---
+
+# Resource profiles in Microsoft Fabric overview
+
+Resource profiles in Microsoft Fabric are predefined sets of Apache Spark configurations that tune your workspace for a specific workload pattern—such as read-heavy analytics or write-heavy ingestion—without manual trial and error. Setting a single property applies a tested collection of Spark and Delta Lake settings, giving you predictable performance by default.
+
+This article explains the concepts behind resource profiles, the difference between selecting a profile and enabling *auto-update*, and how V-Order fits in. Use it as a starting point before you configure profiles or inspect their exact configuration values.
+
+## Key concepts
+
+Two related but distinct mechanisms are involved. Keeping them separate avoids the most common source of confusion.
+
+### 1. The resource profile
+
+A resource profile is the workload preset you select through the `spark.fabric.resourceProfile` property. Setting this property applies that profile's default set of Spark and Delta Lake configurations to your Spark sessions. For example, selecting `readHeavyForPBI` enables V-Order because `spark.sql.parquet.vorder.default=true` is part of that profile's configuration set.
+
+You always have exactly one active profile. New Fabric workspaces default to `writeHeavy`, in which V-Order is disabled to favor ingestion performance. You never "turn off" resource profiles; instead, you switch to a different built-in profile or to `custom` to define your own configurations.
+
+### 2. Auto-update
+
+Auto-update is an optional capability that keeps a profile's configuration aligned with the latest optimizations that Fabric ships over time. It's expressed through the `spark.fabric.resourceProfile.<profileName>AutoUpdate` properties—for example, `spark.fabric.resourceProfile.readHeavyForPBIAutoUpdate`.
+
+Keep the following in mind:
+
+- **Auto-update variants are not separate profiles.** `readHeavyForPBIAutoUpdate` is the auto-update form of the same `readHeavyForPBI` profile—not a new or different profile.
+- **Auto-update isn't required to get a profile's benefits.** Selecting `readHeavyForPBI` already enables V-Order today. Auto-update governs whether Fabric may refresh those tuned values automatically in the future, not whether they apply now.
+- **Auto-update stays within your profile's boundaries.** It adjusts Delta Lake write behavior and file layout for your workload type. It doesn't change your pool size, node configuration, or autoscale settings.
+
+## Available profiles
+
+| Profile | Optimized for | V-Order default |
+| --- | --- | --- |
+| `readHeavyForPBI` | Power BI and DirectLake queries over Delta tables | Enabled |
+| `readHeavyForSpark` | Spark workloads with frequent reads | Disabled (optimized write) |
+| `writeHeavy` (default) | High-frequency ingestion, ETL, and streaming | Disabled |
+| `custom` | Fully user-defined configuration | User-defined |
+
+To enable V-Order through a profile for Power BI and DirectLake scenarios, use `readHeavyForPBI`. For the complete list of properties each profile applies, see [Resource profile configurations](configure-resource-profile-configurations.md).
+
+## Choose your next step
+
+- To learn how to select a workload-based recommendation and apply a profile to your workspace, see [Configure resource profiles](configure-resource-profiles.md).
+- To review the exact Spark and Delta Lake properties that each profile and auto-update variant applies, see [Resource profile configurations](configure-resource-profile-configurations.md).
+- To understand how V-Order accelerates read-heavy workloads, see [Delta Lake table optimization and V-Order](delta-optimization-and-v-order.md).
+
+## Related content
+
+- [Configure resource profiles](configure-resource-profiles.md)
+- [Resource profile configurations](configure-resource-profile-configurations.md)
+- [Delta Lake table optimization and V-Order](delta-optimization-and-v-order.md)

--- a/docs/data-engineering/toc.yml
+++ b/docs/data-engineering/toc.yml
@@ -596,10 +596,14 @@ items:
         href: autoscale-billing-for-spark-overview.md
       - name: Configure autoscale billing
         href: configure-autoscale-billing.md
-      - name: Resource profile configurations
-        href: configure-resource-profile-configurations.md
-      - name: Configure resource profiles
-        href: configure-resource-profiles.md
+      - name: Resource profiles
+        items:
+        - name: Overview
+          href: resource-profiles-overview.md
+        - name: Configure resource profiles
+          href: configure-resource-profiles.md
+        - name: Resource profile configurations
+          href: configure-resource-profile-configurations.md
     - name: Job operations and monitoring
       items:
       - name: Job admission and management


### PR DESCRIPTION
## Summary

Adds a new **Resource profiles overview** page for Fabric Data Engineering and reorganizes the two existing resource profile articles under a single TOC group.

## Why

Community feedback (and a recurring forum thread) shows the current articles are easy to misread: readers think `readHeavyForPBIAutoUpdate` is a *separate/new* resource profile and that auto-update must be enabled before a profile (for example, V-Order via `readHeavyForPBI`) takes effect. This overview sets the context up front and clearly separates the two concepts:

1. **The resource profile** you select via `spark.fabric.resourceProfile` (applies the profile's config set immediately — e.g. `readHeavyForPBI` enables V-Order today).
2. **Auto-update** (`spark.fabric.resourceProfile.<name>AutoUpdate`) — an optional layer that keeps a profile's tuned values current over time. It is **not** a separate profile and is **not** required for a profile's settings to apply.

## Changes

- **New:** `docs/data-engineering/resource-profiles-overview.md` — concepts, profile-vs-auto-update distinction, available-profiles table, and cross-links (relative paths) to the two existing how-to pages and the V-Order article.
- **TOC:** grouped *Overview → Configure resource profiles → Resource profile configurations* under a single **Resource profiles** node in `docs/data-engineering/toc.yml`.

## Follow-up (not in this PR)

The V-Order article (`delta-optimization-and-v-order.md`) states `readHeavyForSpark` enables V-Order, but per the configuration reference only `readHeavyForPBI` sets `spark.sql.parquet.vorder.default=true`. Recommend a one-line correction in a separate PR.
