### PR TITLE
Mirroring for Google BigQuery: GA content updates

### DIFF
--- a/docs/mirroring/google-bigquery-cost.md
+++ b/docs/mirroring/google-bigquery-cost.md
@@ -2,7 +2,7 @@
 title: "The Cost of Mirroring for Google BigQuery"
 description: Learn more about how the cost of Mirroring for Google BigQuery works. 
 ms.reviewer: misaacs
-ms.date: 09/09/2025
+ms.date: 08/14/2026
 ms.topic: how-to
 ---
 

--- a/docs/mirroring/google-bigquery-faq.yml
+++ b/docs/mirroring/google-bigquery-faq.yml
@@ -5,7 +5,7 @@ metadata:
   ms.reviewer: misaacs
   ms.subservice: data-warehouse
   ms.topic: faq
-  ms.date: 09/09/2025
+  ms.date: 08/14/2026
 title: "Frequently asked questions for mirroring Google BigQuery in Microsoft Fabric"
 summary: |
   This article answers frequently asked questions about mirroring BigQuery in Microsoft Fabric. 

--- a/docs/mirroring/google-bigquery-limitations.md
+++ b/docs/mirroring/google-bigquery-limitations.md
@@ -2,7 +2,7 @@
 title: "Limitations in Microsoft Fabric mirrored databases from Google BigQuery"
 description: Learn about the limitations in mirrored databases from Google BigQuery in Microsoft Fabric.
 ms.reviewer: misaacs
-ms.date: 09/09/2025
+ms.date: 08/14/2026
 ms.topic: concept-article
 ---
 

--- a/docs/mirroring/google-bigquery-security.md
+++ b/docs/mirroring/google-bigquery-security.md
@@ -2,7 +2,7 @@
 title: "Data Security in Microsoft Fabric Mirrored Databases From Google BigQuery"
 description: Learn about data security in mirrored databases from Google BigQuery in Microsoft Fabric.
 ms.reviewer: misaacs
-ms.date: 09/09/2025
+ms.date: 08/14/2026
 ms.topic: how-to
 ---
 

--- a/docs/mirroring/google-bigquery-tutorial.md
+++ b/docs/mirroring/google-bigquery-tutorial.md
@@ -1,12 +1,12 @@
 ---
-title: "Set up Mirroring for Google BigQuery (Preview)"
+title: "Set up Mirroring for Google BigQuery"
 description: Learn how to configure a mirrored database from Google BigQuery in Microsoft Fabric.
 ms.reviewer: misaacs
-ms.date: 09/09/2025
+ms.date: 08/14/2026
 ms.topic: tutorial
 ---
  
-# Tutorial: Set up mirroring for Google BigQuery (Preview)
+# Tutorial: Set up mirroring for Google BigQuery
 
 In this tutorial, you'll configure a Fabric mirrored database from Google BigQuery.
 

--- a/docs/mirroring/google-bigquery.md
+++ b/docs/mirroring/google-bigquery.md
@@ -10,6 +10,9 @@ no-loc: [Copilot]
 
 # Mirroring Google BigQuery in Microsoft Fabric
 
+> [!IMPORTANT]
+> Mirroring for Google BigQuery is now generally available. Production workloads are fully supported.
+
 [Mirroring in Fabric](overview.md) offers a simple way to avoid complex ETL (Extract, Transform, Load) processes and seamlessly integrate your existing Google BigQuery warehouse data with the rest of your data in Fabric. You can continuously replicate your Google BigQuery data directly into Fabric's OneLake. Once in Fabric, you can take advantage of powerful capabilities for business intelligence, AI, data engineering, data science, and data sharing.
 
 For a tutorial on configuring your Google BigQuery database for Mirroring in Fabric, see [Tutorial: Configure Microsoft Fabric mirrored databases from Google BigQuery](google-bigquery-tutorial.md).

--- a/docs/mirroring/google-bigquery.md
+++ b/docs/mirroring/google-bigquery.md
@@ -1,21 +1,18 @@
 ---
-title: "Microsoft Fabric Mirrored Databases From Google BigQuery (Preview)"
+title: "Microsoft Fabric Mirrored Databases From Google BigQuery"
 description: Learn about the mirrored databases from Google BigQuery in Microsoft Fabric.
 ms.reviewer: misaacs
-ms.date: 09/09/2025
+ms.date: 08/14/2026
 ms.topic: concept-article
 ms.search.form: Fabric Mirroring
 no-loc: [Copilot]
 ---
 
-# Mirroring Google BigQuery in Microsoft Fabric (Preview)
+# Mirroring Google BigQuery in Microsoft Fabric
 
 [Mirroring in Fabric](overview.md) offers a simple way to avoid complex ETL (Extract, Transform, Load) processes and seamlessly integrate your existing Google BigQuery warehouse data with the rest of your data in Fabric. You can continuously replicate your Google BigQuery data directly into Fabric's OneLake. Once in Fabric, you can take advantage of powerful capabilities for business intelligence, AI, data engineering, data science, and data sharing.
 
 For a tutorial on configuring your Google BigQuery database for Mirroring in Fabric, see [Tutorial: Configure Microsoft Fabric mirrored databases from Google BigQuery](google-bigquery-tutorial.md).
-
-> [!IMPORTANT]
-> Mirroring for Google BigQuery is now in [preview](../fundamentals/preview.md). Production workloads aren't supported during preview.
 
 ## Why use mirroring in Fabric?
 


### PR DESCRIPTION
## Summary

Doc updates for the **General Availability of Mirroring for Google BigQuery in Microsoft Fabric**.

## Changes

### Preview → GA
- `google-bigquery.md`:
  - Drop `(Preview)` from title and H1.
  - Replace the preview `> [!IMPORTANT]` callout with a **GA IMPORTANT callout** at the top of the article: *"Mirroring for Google BigQuery is now generally available. Production workloads are fully supported."*
- `google-bigquery-tutorial.md`: drop `(Preview)` from title and H1.
- All GBQ mirroring articles (`google-bigquery*.md`, `google-bigquery-faq.yml`): bump `ms.date` to `08/14/2026`.

Body content on all existing sections (Why use mirroring in Fabric?, What analytics experiences are built in?, Security considerations, Cost, Next step) is intentionally left as-is.

## Why
Mirroring for Google BigQuery is GA-ing alongside the FabCon EU keynote. Docs need to (1) drop preview framing, (2) surface the GA milestone via a top-of-article callout, and (3) confirm production support.

## Reviewer
@misaacs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>