### PR TITLE
Remove temporary Eventstream monitoring warning

### DIFF
--- a/docs/real-time-intelligence/event-streams/query-fabric-workspace-monitoring-data.md
+++ b/docs/real-time-intelligence/event-streams/query-fabric-workspace-monitoring-data.md
@@ -20,9 +20,6 @@ You can query your Eventstream monitoring data using KQL (Kusto Query Language) 
 > [!NOTE]
 > Eventstream workspace monitoring is currently in preview.
 
-> [!IMPORTANT]
-> Workspace monitoring for eventstreams  is temporarily disabled. The product team identified an issue that required disabling the feature. They're implementing a fix with improved controls. For more information, see the [Eventstream workspace monitoring known issue](https://support.fabric.microsoft.com/known-issues/?product=Real-Time%2520Intelligence&active=true&fixed=true&sort=published&issueId=1824). 
-
 ## Check the status of all nodes
 
 This query returns the most recent status of each node in a specific Eventstream.


### PR DESCRIPTION
## Summary

Remove the temporary service-disable warning now that Eventstream workspace monitoring is available again.